### PR TITLE
Add a calculation for Nu to the Blankenbach case.

### DIFF
--- a/notebooks/blankenbach.ipynb
+++ b/notebooks/blankenbach.ipynb
@@ -219,6 +219,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e35ffff5-da4d-4598-80b0-2493134fe401",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def top(x):\n",
+    "    return np.isclose(x[1], 1)\n",
+    "fdim = domain.topology.dim - 1\n",
+    "top_facets = df.mesh.locate_entities_boundary(domain, fdim, top)\n",
+    "top_values = np.full_like(top_facets, 1)\n",
+    "sorted_facets = np.argsort(top_facets)\n",
+    "facet_tag = df.mesh.meshtags(domain, fdim, top_facets[sorted_facets], top_values[sorted_facets])\n",
+    "ds = ufl.Measure('ds', domain=domain, subdomain_data=facet_tag)\n",
+    "\n",
+    "def Nu():\n",
+    "    nu = -fem.assemble_scalar(fem.form(T_i.dx(1)*ds(1)))\n",
+    "    return MPI.COMM_WORLD.allreduce(nu, op=MPI.SUM)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e793ddf9-00c4-40c1-b909-7502a54d50a2",
    "metadata": {},
    "outputs": [],
@@ -260,7 +281,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "v_rms()"
+    "v_rms(), Nu()"
    ]
   },
   {


### PR DESCRIPTION
We're missing one of the diagnostics from the Blankenbach case because we didn't have the top surface defined.  This PR adds a cell of code that tags the top facets and then assembles the surface integral of the temperature derivative w.r.t. y (e.g. the Nusselt number, Nu).